### PR TITLE
Unificate how printf uses arguments of log record. Make possible to format error with %e to show error stack.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 npm-debug.log
+.idea

--- a/lib/utils/printf.js
+++ b/lib/utils/printf.js
@@ -4,10 +4,10 @@
 
 const SLICE = Array.prototype.slice;
 
-const RE = /%(%|(\([^\)]+\))?([sdO]))/g;
+const RE = /%(%|(\([^\)]+\))?([esdO]))/g;
 
 module.exports = function(format, obj) {
-  var args = SLICE.call(arguments, 1);
+  var args = obj.args;
   var counter = 0;
   return String(format).replace(RE, function(match, kind, name, type) {
     if (kind === '%') {
@@ -28,6 +28,8 @@ module.exports = function(format, obj) {
       return Number(val);
     case 'O':
       return JSON.stringify(val);
+    case 'e':
+      return val instanceof Error ? val.stack : '';
     default:
       return match;
     }

--- a/test/printf.js
+++ b/test/printf.js
@@ -12,10 +12,10 @@ module.exports = {
       assert.equal(printf('%(foo)s:%(bar)s', { foo: 'a', bar: 'b' }), 'a:b');
     },
     'should print args': function() {
-      assert.equal(printf('%s,%s,%d', 'a', 2, 3), 'a,2,3');
+      assert.equal(printf('%s,%s,%d', { args: ['a', 2, 3] } ), 'a,2,3');
     },
     'should print %O': function() {
-      assert.equal(printf('%O', { foo: 'bar' }), '{"foo":"bar"}');
+      assert.equal(printf('%O', { args: [{ foo: 'bar' }] }), '{"foo":"bar"}');
     }
   }
 };


### PR DESCRIPTION
Arguments in printf was useless for log record. I'd like to see your opinion.
