### PR TITLE
fix rotating file handler write lock

### DIFF
--- a/lib/handlers/rotating.js
+++ b/lib/handlers/rotating.js
@@ -50,6 +50,8 @@ RotatingFileHandler.prototype._write = function write() {
   if (this._buffer.length) {
     var tuple = this._buffer.shift();
     this._withSize(tuple[0], tuple[1]);
+  } else {
+    this._writing = false;
   }
 };
 

--- a/test/handlers.js
+++ b/test/handlers.js
@@ -261,6 +261,21 @@ module.exports = {
           assert.equal(fs.statSync(filename + '.2').size, 56);
           assert(!fs.existsSync(filename + '.3'));
         }).done(done);
+      },
+      'should continue to write after buffer is flushed': function(done) {
+        this.timeout(5000);
+
+        var filename = tmp();
+        var handler = new intel.handlers.Rotating({
+          file: filename,
+          maxSize: 64
+        });
+
+        handler.handle({ message: bytes(29) }).then(function(){
+          return handler.handle({ message: bytes(31) });
+        }).then(function(){
+          assert.equal(fs.statSync(filename).size, 62);
+        }).done(done);
       }
     }
   }


### PR DESCRIPTION
This commit fixes a bug when RotatingFileHandler was always writing only
one log record to the file if it had already wrote a record before the
new one came in. This was caused by not setting write flag to false if
the buffer is empty.
