### PR TITLE
Add formatter option to strip ANSI escape codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ A `Formatter` is used by a [`Handler`](#handlers) to format the message before b
 
 - **format**: A format string that will be used with `printf`. Default: `%(message)s`
 - **datefmt**: A string to be used to format the date. Will replace instances of `%(date)s` in the `format` string. Default: `%Y-%m-%d %H:%M-%S`
-- **colorize**: A boolean for whether to colorize the `levelname`. Default: `false`
+- **strip**: A boolean for whether to strip [ANSI escape codes](http://en.wikipedia.org/wiki/ANSI_escape_code#Colors_and_Styles) from the `message` and `args`. Default: `false`
+- **colorize**: A boolean for whether to colorize the `levelname`. Disabled when `strip` is used. Default: `false`
 
 ### LogRecord
 
@@ -337,7 +338,8 @@ intel.config({
       'colorize': true
     },
     'details': {
-      'format': '[%(date)s] %(name)s.%(levelname)s: %(message)s'
+      'format': '[%(date)s] %(name)s.%(levelname)s: %(message)s',
+      'strip': true
     }
   },
   filters: {
@@ -415,7 +417,7 @@ Options:
 
 - **root** - String to define root logger, defaults to calling module's filename
 - **ignore** - Array of strings of log names that should be ignored and use standard `console` methods. Ex: `['intel.node_modules.mocha']`
-- **debug** - boolean or String. `true` will set `process.env.DEBUG='*'``. Otherwise, String is used, ex: `'request,express'`
+- **debug** - boolean or String. `true` will set `process.env.DEBUG='*'`. Otherwise, String is used, ex: `'request,express'`
 
 ```js
 // file: patrol/index.js

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -20,8 +20,11 @@ function Formatter(options) {
     if ('datefmt' in options) {
       this._datefmt = options.datefmt;
     }
+    if ('strip' in options) {
+      this._strip = options.strip;
+    }
     if ('colorize' in options) {
-      this._colorize = options.colorize;
+      this._colorize = this._strip ? false : options.colorize;
     }
   } else if (typeof options === 'string') {
     this._format = options;
@@ -48,14 +51,18 @@ Formatter.prototype = {
 
   _colorize: false,
 
+  _strip: false,
+
   _usesTime: false,
 
   format: function format(record) {
     if (this._usesTime) {
       record.date = this.formatDate(record);
     }
+
     var levelname = record.levelname;
     var name = record.name;
+
     if (this._colorize) {
       var colorize = COLORS[levelname];
       if (colorize) {
@@ -64,6 +71,7 @@ Formatter.prototype = {
       // else levelname doesnt have a color
       record.name = chalk.bold(name);
     }
+
     var formatted;
     switch (this._format) {
       // faster shortcuts
@@ -85,8 +93,13 @@ Formatter.prototype = {
     if (record.stack && this._format !== TO_JSON) {
       formatted += record.stack;
     }
+
     record.levelname = levelname;
     record.name = name;
+
+    if (this._strip) {
+      formatted = chalk.stripColor(formatted);
+    }
 
     return formatted;
   },

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -16,17 +16,29 @@ module.exports = {
         assert.equal(formatter._format, '%(level)s');
         assert.equal(formatter._datefmt, intel.Formatter.prototype._datefmt);
         assert.equal(formatter._colorize, false);
+        assert.equal(formatter._strip, false);
       },
       'should accept options': function() {
         var formatter = new intel.Formatter({
           format: '%(levelname)s',
           datefmt: '%Y',
-          colorize: true
+          colorize: true,
+          strip: false
         });
 
         assert.equal(formatter._format, '%(levelname)s');
         assert.equal(formatter._datefmt, '%Y');
         assert.equal(formatter._colorize, true);
+        assert.equal(formatter._strip, false);
+      },
+      'should disable colorize when strip is enabled': function() {
+        var formatter = new intel.Formatter({
+          colorize: true,
+          strip: true
+        });
+
+        assert.equal(formatter._strip, true);
+        assert.equal(formatter._colorize, false);
       }
     },
 
@@ -110,6 +122,27 @@ module.exports = {
 
           assert.equal(formatter.format(record),
               '\u001b[31m\u001b[1mERROR\u001b[22m\u001b[39m: foo');
+        }
+      },
+      'strip': {
+        'should strip ANSI escape codes from the output': function() {
+          var formatter = new intel.Formatter({
+            format: '%(levelname)s: %(message)s [%(args)s]',
+            strip: true
+          });
+
+          var record = {
+            levelname: 'INFO',
+            message: '\u001b[36mHello World\u001b[39m',
+            args: [
+              '\u001b[31mFoo\u001b[39m',
+              '\u001b[35mBar\u001b[39m',
+              '\u001b[33mBaz\u001b[39m'
+            ]
+          };
+
+          assert.equal(formatter.format(record),
+              'INFO: Hello World [Foo,Bar,Baz]');
         }
       }
     }


### PR DESCRIPTION
Adds an option to strip ANSI escape codes from log messages. Hooray for pretty colours on the console without filling our log files with garbage!
