### PR TITLE
Workaround to fix issue #34

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -46,7 +46,7 @@ function endsWith(str, suffix) {
 var root;
 var ignore;
 var parentLogger;
-
+var basename;
 
 function getLoggerName(debugName) {
   var trace = stack.get();
@@ -85,7 +85,7 @@ function getLoggerName(debugName) {
       break;
     }
   }
-  var topName = path.basename(root);
+  var topName = basename || path.basename(root);
   topName = topName.replace(path.extname(topName), '');
 
   var moduleName = path.join(topName, path.relative(root, filename));
@@ -221,6 +221,10 @@ function setDebug(debug) {
   dbug.__log = dbugHook;
 }
 
+function setLoggerBaseName(bn){
+  basename = bn;
+}
+
 function deliver(method, args) {
   var debugged = isDebugging && parseDebug(args);
   var name = getLoggerName(dbugName(debugged));
@@ -256,7 +260,7 @@ function overrideConsole(options) {
 
   setDebug(options.debug);
 
-
+  setLoggerBaseName(options.basename);
   if (!ORIGINAL_METHODS.log) {
     copyProperties(console, ORIGINAL_METHODS, METHOD_NAMES);
   }


### PR DESCRIPTION
This fix created to fix unpredictable names for logger of intel.console

just pass basename to options and it will be used instead of path....some.random..magic

so
```javascript
intel.console({root:'/path/to/your/project',basename:'my_project'})
```
will result
```
my_project.node_modules.express.DEBUG: log
my_project.app.DEBUG: log
```