### PR TITLE
Convert thrown Errors to strings in the json formatter

### DIFF
--- a/lib/utils/json.js
+++ b/lib/utils/json.js
@@ -11,6 +11,8 @@ function stringify(obj, indent) {
   return JSON.stringify(obj, function filter(key, val) {
     if (!val || typeof val !== 'object') {
       return val;
+    } else if (val instanceof Error) {
+      return String(val);
     } else if (seen.indexOf(val) !== -1) {
       return '[Circular]';
     }
@@ -20,7 +22,14 @@ function stringify(obj, indent) {
 }
 
 function nativeJson(obj, indent) {
-  return indent ? JSON.stringify(obj, null, indent) : JSON.stringify(obj);
+  function replacer(key, val) {
+    if (val instanceof Error) {
+      return String(val);
+    }
+    return val;
+  }
+  return indent ? JSON.stringify(obj, replacer, indent)
+                : JSON.stringify(obj, replacer);
 }
 
 module.exports = function json(obj, indent) {


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-server/issues/1279, the default printer does not unwrap exceptions in json objects.
(Will add tests later if you think this is the right approach)