### PR TITLE
Check error stack in record

### DIFF
--- a/lib/record.js
+++ b/lib/record.js
@@ -59,7 +59,7 @@ function Record(name, level, args) {
   }
   this.exception = isErr;
   this.uncaughtException = isErr ? trace[UNCAUGHT_SYMBOL] : undefined;
-  this.stack = trace ? stack(trace) : undefined;
+  this.stack = trace && trace.stack ? stack(trace) : undefined;
 
 }
 

--- a/test/logger.js
+++ b/test/logger.js
@@ -202,6 +202,19 @@ module.exports = {
         assert(obj[0].fileName);
         assert.equal(record.exception, true);
       },
+      'should be with empty stack if NONE err.stack': function(){
+        var a = new Logger(unique());
+        a.propagate = false;
+        var spyA = spy();
+        a.addHandler({ handle: spyA, level: 0 });
+
+        var error = new Error('foo');
+        delete error.stack;
+        a.error(error);
+
+        var record = spyA.getLastArgs()[0];
+        assert.equal(record.stack, undefined);
+      },
       'ALL should receive all levels': function() {
         var a = new Logger(unique());
         a.propagate = false;


### PR DESCRIPTION
Hi, this PR fixes a TypeError on logging Error without stack trace (this is sometimes useful).

Steps to reproduce a problem

1. create a file in root dir of `intel`, put this:
```
var intel = require('./lib'); // or 'intel'

var err = new Error();
delete err.stack;

intel.error(err);
```
2. run `node test.js`
```
/Users/ruslan/www/intel/lib/record.js:24
      return e.stack.substr(e.stack.indexOf('\n'));
                    ^

TypeError: Cannot read property 'substr' of undefined
    at Object.toString (/Users/ruslan/www/intel/lib/record.js:24:21)
    at Object.format (/Users/ruslan/www/intel/lib/formatter.js:109:26)
    at StreamHandler.format (/Users/ruslan/www/intel/lib/handlers/handler.js:52:28)
    at StreamHandler.streamEmit [as _emit] (/Users/ruslan/www/intel/lib/handlers/stream.js:21:27)
    at ConsoleHandler.consoleEmit [as _emit] (/Users/ruslan/www/intel/lib/handlers/console.js:24:11)
    at ConsoleHandler.emit (/Users/ruslan/www/intel/lib/handlers/handler.js:13:15)
    at Logger.handle (/Users/ruslan/www/intel/lib/logger.js:218:29)
    at Logger.handle (/Users/ruslan/www/intel/lib/index.js:20:20)
    at Logger._log (/Users/ruslan/www/intel/lib/logger.js:249:20)
    at Logger.error (/Users/ruslan/www/intel/lib/logger.js:81:19)
```