### PR TITLE
Update error check to avoid deprecation warning in NodeJS 22

### DIFF
--- a/lib/record.js
+++ b/lib/record.js
@@ -53,7 +53,7 @@ function Record(name, level, args) {
   var i = args.length;
   while (i--) {
     var a = args[i];
-    if (a && ((isErr = util.isError(a)) || a instanceof Trace)) {
+    if (a && ((isErr = Object.prototype.toString.call(a) === '[object Error]' || a instanceof Error) || a instanceof Trace)) {
       trace = a;
       break;
     }


### PR DESCRIPTION
Using NodeJS 22 you get a deprecation warning like this: 

```(node:12388) [DEP0048] DeprecationWarning: The `util.isError` API is deprecated. Please use `ObjectPrototypeToString(e) === "[object Error]" || e instanceof Error` instead.```